### PR TITLE
Fix conflict between arrow-body-style and no-confusing-arrow

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
     "newline-after-var": ["error", "always"],
     "newline-before-return": "error",
     "no-array-constructor": "error",
-    "no-confusing-arrow": "error",
+    "no-confusing-arrow": ["error", {"allowParens": true}],
     "no-console": "error",
     "no-eval": "error",
     "no-extend-native": "error",


### PR DESCRIPTION
This code violates `arrow-body-style`:
```jsx
const a = (b) => {
  return b ? 0 : 1;
};
```
If you run `eslint --fix`, it will change it to this code that violates `no-confusing-arrow` and doesn't auto-fix:
```jsx
const a = (b) => b ? 0 : 1;
```
Without the `allowParens` flag against `no-confusing-arrow`, the only way to solve for both constraints is to unpack ternary operators in lambdas into `if` statements.

With the `allowParens` flag, it's possible to resolve the issue by putting parentheses around the body of the lambda, i.e.
```jsx
const a = (b) => (b ? 0 : 1);
```